### PR TITLE
Don't use archive.a.o directly, change to use Maven Central

### DIFF
--- a/cargo/Maven2+Plugin+Getting+Started.html
+++ b/cargo/Maven2+Plugin+Getting+Started.html
@@ -291,10 +291,10 @@
            <div class="codeContent panelContent pdl"> 
             <pre class="syntaxhighlighter-pre" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence">mvn clean verify org.codehaus.cargo:cargo-maven2-plugin:run
     -Dcargo.maven.containerId=tomcat7x
-    -Dcargo.maven.containerUrl=http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.16/bin/apache-tomcat-7.0.16.zip
+    -Dcargo.maven.containerUrl=http://repo2.maven.org/maven2/org/apache/tomcat/tomcat/7.0.61/tomcat-7.0.61.zip
 </pre> 
            </div>
-          </div><p>That command will automatically download Tomcat 7.0.16 from the specified URL (taking into account any proxy server setting you would have in Maven2/Maven3), instantiate the container, create a local configuration with your application and run it. It will also save the downloaded container in the default directory (see the <a href="Maven2+Plugin+Reference+Guide.html">Maven2 Plugin Reference Guide</a> for details), so it won't get downloaded when you run the same command twice.</p><p>Now, if you want to run this time on <a href="Glassfish+3.x.html">Glassfish 3.x</a> with with the HTTP port set to <code>9000</code>, run:</p>
+          </div><p>That command will automatically download Tomcat 7.0.61 from the specified URL (taking into account any proxy server setting you would have in Maven2/Maven3), instantiate the container, create a local configuration with your application and run it. It will also save the downloaded container in the default directory (see the <a href="Maven2+Plugin+Reference+Guide.html">Maven2 Plugin Reference Guide</a> for details), so it won't get downloaded when you run the same command twice.</p><p>Now, if you want to run this time on <a href="Glassfish+3.x.html">Glassfish 3.x</a> with with the HTTP port set to <code>9000</code>, run:</p>
           <div class="code panel pdl conf-macro output-block" style="border-width: 1px;" data-hasbody="true" data-macro-name="code">
            <div class="codeContent panelContent pdl"> 
             <pre class="syntaxhighlighter-pre" data-syntaxhighlighter-params="brush: xml; gutter: false; theme: Confluence" data-theme="Confluence">mvn clean verify org.codehaus.cargo:cargo-maven2-plugin:run


### PR DESCRIPTION
Downtime of the ASF Archives site recently highlighted that some projects are linking to archive.a.o directly. This site is mainly to store old releases historically as is not meant as a download site.

Please use Maven Central instead.

Tomcat 7.0.16 is not on Maven Central however, so changed to 7.0.61 instead.

HTH